### PR TITLE
Change the type of government from Constitutional Monarchy to Parliam…

### DIFF
--- a/Countrydetails/data/countries/barbados.json
+++ b/Countrydetails/data/countries/barbados.json
@@ -172,6 +172,6 @@
     "religion": "Christianity",
     "temperature": 26,
     "continent": "North America",
-    "government": "Constitutional Monarchy",
+    "government": "Parliamentary Republic",
     "wiki": "http://en.wikipedia.org/wiki/barbados"
 }


### PR DESCRIPTION
Change the type of government for Barbados from Constitutional Monarchy to Parliamentary Republic

