### PR TITLE
Use lowercase data directory in `MANIFEST.in` when bundling package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 
 
 include README.md LICENSE
-recursive-include Countrydetails/Data *
+recursive-include Countrydetails/data *
 recursive-include Countrydetails/cli_dir *


### PR DESCRIPTION
When on Windows OS. paths are case insensitive, however the `MANIFEST.in` will match `Data` when bundling the package. 

Partially addresses issues #8  and #9, but would need a new version of the package to be released.