### PR TITLE
fix: Handle both `data/`and `Data/` directory paths in countries.py

### DIFF
--- a/Countrydetails/countries.py
+++ b/Countrydetails/countries.py
@@ -1,5 +1,5 @@
 from glob import glob
-from os.path import isfile, realpath, dirname
+from os.path import isdir, isfile, realpath, dirname, join
 import json
 
 
@@ -15,11 +15,15 @@ class all_countries:
     def __init__(self):
         """constructor method"""
         dir_path = dirname(realpath(__file__))
-        countries_file_path = dir_path + '/data/countries.json'
-        continents_file_path = dir_path + '/data/continents.json'
-        region_file_path = dir_path + '/data/region.json'
-        states_file_path = dir_path + '/data/states.json'
-        languages_to_capitals_file_path = dir_path + '/data/langtocountries.json'
+        data_path = join(dir_path, 'data')
+        # NOTE: MANIFEST.in may cause package data to be stored under "Data/" instead of "data/" depending on OS
+        if not isdir(data_path):
+            data_path = join(dir_path, 'Data')
+        countries_file_path = join(data_path, 'countries.json')
+        continents_file_path = join(data_path, 'continents.json')
+        region_file_path = join(data_path, 'region.json')
+        states_file_path = join(data_path, 'states.json')
+        languages_to_capitals_file_path = join(data_path, 'langtocountries.json')
         with open(countries_file_path, encoding='utf-8') as file:
             countries_file = json.load(file)
             self.countries_file = countries_file


### PR DESCRIPTION
Fixes #8 and #9 by checking for `data/` directory and using `Data/` if it does not exist (brought about by `MANIFEST.in` 